### PR TITLE
Clamp require

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,13 +1,13 @@
-julia 0.6
-Images
-ImageView
-ImageDraw
-ImageFeatures
-VideoIO
-ImageFiltering
-TestImages
-TransformUtils
-CoordinateTransformations
-StaticArrays
-Rotations
+julia 0.6 0.7.0-
+Images 0.14.0 0.15.0-
+ImageView 0.6.0 0.7.0-
+ImageDraw 0.0.1 0.1.0-
+ImageFeatures 0.0.2 0.1.0-
+VideoIO 0.2.0 0.3.0-
+ImageFiltering 0.3.0 0.4.0-
+TestImages 0.2.0 0.3.0-
+TransformUtils 0.1.0 0.2.0-
+CoordinateTransformations 0.4.1 0.5.0-
+StaticArrays 0.7.2 0.8.0-
+Rotations 0.7.2 0.8.0-
 #RecursiveFiltering


### PR DESCRIPTION
Clamp package versions to where they were last working.
This will probably be the last version to work on julia 0.6